### PR TITLE
CAT-23416 Added log_group_class for aws_cloudwatch_log_group

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ### Using the Repo Source
 
 ```hcl
-github.com/pbs/terraform-aws-ecs-task-definition-module?ref=1.0.26
+github.com/pbs/terraform-aws-ecs-task-definition-module?ref=x.y.z
 ```
 
 ### Alternative Installation Methods
@@ -22,7 +22,7 @@ Integrate this module like so:
 
 ```hcl
 module "task" {
-  source = "github.com/pbs/terraform-aws-ecs-task-definition-module?ref=1.0.26"
+  source = "github.com/pbs/terraform-aws-ecs-task-definition-module?ref=x.y.z"
 
   # Tagging Parameters
   organization = var.organization
@@ -40,7 +40,7 @@ module "task" {
 
 If this repo is added as a subtree, then the version of the module should be close to the version shown here:
 
-`1.0.26`
+`x.y.z`
 
 Note, however that subtrees can be altered as desired within repositories.
 
@@ -58,7 +58,7 @@ Below is automatically generated documentation on this Terraform module using [t
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.30.0 |
 
 ## Providers
 
@@ -109,6 +109,7 @@ No modules.
 | <a name="input_envoy_tag"></a> [envoy\_tag](#input\_envoy\_tag) | (optional) tag for envoy. Update periodically if using App Mesh. | `string` | `"v1.23.1.0-prod"` | no |
 | <a name="input_image_repo"></a> [image\_repo](#input\_image\_repo) | (optional) image repo. e.g. image\_repo = nginx --> nginx:image\_tag | `string` | `"nginx"` | no |
 | <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | (optional) tag of the image. e.g. image\_tag = latest --> image\_repo:latest | `string` | `"alpine"` | no |
+| <a name="input_log_group_class"></a> [log\_group\_class](#input\_log\_group\_class) | (Optional) log class of the log group. Possible values are: STANDARD or INFREQUENT\_ACCESS | `string` | `"INFREQUENT_ACCESS"` | no |
 | <a name="input_log_group_name"></a> [log\_group\_name](#input\_log\_group\_name) | (optional) name for the log group | `string` | `null` | no |
 | <a name="input_memory_reservation"></a> [memory\_reservation](#input\_memory\_reservation) | (optional) memory reservation for task | `number` | `512` | no |
 | <a name="input_mesh_name"></a> [mesh\_name](#input\_mesh\_name) | (optional) the name for the App Mesh this task is associated with. If null, ignored | `string` | `null` | no |

--- a/logs.tf
+++ b/logs.tf
@@ -9,6 +9,8 @@ resource "aws_cloudwatch_log_group" "logs" {
 
   retention_in_days = var.retention_in_days
 
+  log_group_class = var.log_group_class
+
   tags = {
     Name        = "${local.service_name} Log Group"
     application = var.product

--- a/optional-logs.tf
+++ b/optional-logs.tf
@@ -10,6 +10,12 @@ variable "log_group_name" {
   type        = string
 }
 
+variable "log_group_class" {
+  description = "(Optional) log class of the log group. Possible values are: STANDARD or INFREQUENT_ACCESS"
+  default     = "INFREQUENT_ACCESS"
+  type        = string
+}
+
 variable "retention_in_days" {
   description = "(optional) log retention in days"
   default     = 7

--- a/terraform.tf
+++ b/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     # tflint-ignore: terraform_unused_required_providers
     aws = {
-      version = ">= 4.5.0"
+      version = ">= 5.30.0"
     }
   }
 }


### PR DESCRIPTION
Added the  log_group_class for the aws_cloudwatch_log_group.
Updated the minimum AWS provider version to 5.30.0.
As per documentation, the log group will be recreated if you change the value from STANDARD to INFREQUENT_ACCESS.